### PR TITLE
view-cart-summary-front-end-completed | Andrew Zhou

### DIFF
--- a/client/components/app.jsx
+++ b/client/components/app.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Header from './header';
 import ProductList from './product-list';
 import ProductDetails from './product-details';
+import CartSummary from './cart-summary';
 
 export default class App extends React.Component {
   constructor(props) {
@@ -71,10 +72,12 @@ export default class App extends React.Component {
       renders = <ProductList setView={this.setView} />;
     } else if (name === 'details') {
       renders = <ProductDetails view={this.state.view} click={this.setView} add={this.addToCart} />;
+    } else if (name === 'cart') {
+      renders = <CartSummary click={this.setView} cartArray={this.state.cart} />;
     }
     return (
       <div className="container-fluid">
-        <Header cartItemCount={this.state.cart.length} />
+        <Header cartItemCount={this.state.cart.length} click={this.setView} />
         {
           renders
         }

--- a/client/components/cart-summary.item.jsx
+++ b/client/components/cart-summary.item.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+const CartSummaryItem = props => {
+  const item = props.item;
+  return (
+    <div className="card cart-card my-2" >
+      <div className="row no-gutters">
+        <div className="col-6 card-left">
+          <img src={item.image} alt={item.name} className="cover" />
+        </div>
+        <div className="col-6">
+          <div className="card-body">
+            <h5 className="card-title"> {item.name} </h5>
+            <p className="card-text h4"> {'$' + (item.price / 100).toFixed(2)} </p>
+            <p className="card-te"> {item.shortDescription} </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CartSummaryItem;

--- a/client/components/cart-summary.jsx
+++ b/client/components/cart-summary.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import CartSummaryItem from './cart-summary.item';
+
+const CartSummary = props => {
+  const cartArray = props.cartArray;
+  let totalPrice = 0;
+  if (cartArray) {
+    cartArray.forEach(element => { totalPrice += parseInt((element.price / 100).toFixed(2), 10); });
+  }
+  if (!cartArray) return <h1>Your Cart Is Empty!</h1>;
+  return (
+    <div className="container">
+      <p className="h2 my-4">My Cart</p>
+      <button className="btn btn-outline-success mb-4" onClick={() => props.click('catalog', { params: {} })} >Back to Catalog</button>
+      {
+        cartArray.map(individual => {
+          return <CartSummaryItem item={individual} key={individual.productId} />;
+        })
+      }
+      <p className="my-4 h2"> {`Item Total $${totalPrice}`} </p>
+    </div>
+  );
+};
+
+export default CartSummary;

--- a/client/components/header.jsx
+++ b/client/components/header.jsx
@@ -8,7 +8,7 @@ const Header = props => {
         <p className={property}>
         $Wicked Sales
         </p>
-        <p className={property}>
+        <p className={property + ' cursor'} onClick={() => props.click('cart', {})} >
           {
           `${props.cartItemCount} Items `
           }

--- a/server/public/styles.css
+++ b/server/public/styles.css
@@ -1,3 +1,6 @@
+.card-left, .row, .cover, .fill {
+  height: 99%;
+}
 .card {
   height: 500px;
 }
@@ -5,9 +8,15 @@
   height: 50%;
 }
 .fill {
-  height: 100%;
   object-fit: scale-down;
 }
 .cursor {
   cursor: pointer;
+}
+.cover {
+  width: 100%;
+  object-fit: scale-down;
+}
+.card.cart-card {
+  height: 400px;
 }


### PR DESCRIPTION
modified stylesheet to set card and image size
added two new components: cart-sum & cart-sum-item
cart-sum creates cart-dom tree based on app's state
cart-sum-item generates user chosen products
requires furthur cleanse
<img width="943" alt="Screen Shot 2020-01-15 at 10 13 13 AM" src="https://user-images.githubusercontent.com/55771037/72459630-0a843700-3780-11ea-9ac5-2fb680807d97.png">
